### PR TITLE
patch: increase stability days

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "cSpell.words": ["mightyhealth"]
+}

--- a/default.json
+++ b/default.json
@@ -2,10 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "semanticCommits": "enabled",
   "semanticCommitType": "build",
-  "lockFileMaintenance": {
-    "enabled": true,
-    "automerge": true
-  },
   "labels": [
     "dependencies",
     "bot"

--- a/default.json
+++ b/default.json
@@ -9,7 +9,7 @@
   "dependencyDashboard": true,
   "branchConcurrentLimit": 0,
   "prConcurrentLimit": 0,
-  "stabilityDays": 30,
+  "stabilityDays": 90,
   "prCreation": "status-success",
   "automergeType": "branch",
   "automerge": true,


### PR DESCRIPTION
Currently, we have too many open pull requests due to Renovate. Since we cannot review these PRs at the same rate as they are created, updating the number of stability days will reduce the number of PRs created by Renovate. This will give engineers more time to review the PRs instead of ignoring them.